### PR TITLE
Add credential discovery tests

### DIFF
--- a/aws/creds_test.go
+++ b/aws/creds_test.go
@@ -16,8 +16,16 @@
 package aws
 
 import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -57,4 +65,125 @@ func TestScan(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "section2_result", foo)
 	assert.Equal(t, "section2_bar_result", bar)
+}
+
+// helper to run STS-based tests with a mocked STS service
+func withSTSServer(t *testing.T, handler http.HandlerFunc, fn func(client *http.Client)) {
+	srv := httptest.NewTLSServer(handler)
+	t.Cleanup(srv.Close)
+
+	tr := srv.Client().Transport.(*http.Transport).Clone()
+	tr.Proxy = nil
+	if tr.TLSClientConfig != nil {
+		tr.TLSClientConfig.InsecureSkipVerify = true
+	}
+	u, _ := url.Parse(srv.URL)
+	dialer := &net.Dialer{}
+	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if strings.HasPrefix(addr, "sts.amazonaws.com") {
+			addr = u.Host
+		}
+		return dialer.DialContext(ctx, network, addr)
+	}
+	client := &http.Client{Transport: tr}
+	fn(client)
+}
+
+func TestWebIdentityCreds(t *testing.T) {
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "token")
+	err := os.WriteFile(tokenFile, []byte("tok"), 0600)
+	assert.NoError(t, err)
+
+	os.Setenv("AWS_REGION", "us-west-1")
+	defer os.Unsetenv("AWS_REGION")
+	os.Setenv("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/test")
+	defer os.Unsetenv("AWS_ROLE_ARN")
+	os.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", tokenFile)
+	defer os.Unsetenv("AWS_WEB_IDENTITY_TOKEN_FILE")
+	os.Setenv("AWS_ROLE_SESSION_NAME", "mysession")
+	defer os.Unsetenv("AWS_ROLE_SESSION_NAME")
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "application/xml", r.Header.Get("Accept"))
+		q := r.URL.Query()
+		assert.Equal(t, "AssumeRoleWithWebIdentity", q.Get("Action"))
+		assert.Equal(t, "2011-06-15", q.Get("Version"))
+		assert.Equal(t, "arn:aws:iam::123456789012:role/test", q.Get("RoleArn"))
+		assert.Equal(t, "mysession", q.Get("RoleSessionName"))
+		assert.Equal(t, "tok", q.Get("WebIdentityToken"))
+
+		w.Header().Set("Content-Type", "application/xml")
+		w.Write([]byte(`
+<AssumeRoleWithWebIdentityResponse>
+  <AssumeRoleWithWebIdentityResult>
+    <Credentials>
+      <AccessKeyId>AKID</AccessKeyId>
+      <SecretAccessKey>SECRET</SecretAccessKey>
+      <SessionToken>SESSION</SessionToken>
+      <Expiration>2025-01-02T03:04:05Z</Expiration>
+    </Credentials>
+  </AssumeRoleWithWebIdentityResult>
+</AssumeRoleWithWebIdentityResponse>`))
+	}
+
+	withSTSServer(t, handler, func(client *http.Client) {
+		id, secret, region, token, expiration, err := WebIdentityCreds(client)
+		assert.NoError(t, err)
+		assert.Equal(t, "AKID", id)
+		assert.Equal(t, "SECRET", secret)
+		assert.Equal(t, "us-west-1", region)
+		assert.Equal(t, "SESSION", token)
+		wantTime, _ := time.Parse(time.RFC3339, "2025-01-02T03:04:05Z")
+		assert.True(t, expiration.Equal(wantTime))
+	})
+}
+
+func TestAmbientCreds(t *testing.T) {
+	os.Setenv("AWS_ACCESS_KEY_ID", "AKID")
+	defer os.Unsetenv("AWS_ACCESS_KEY_ID")
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "SECRET")
+	defer os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+	os.Setenv("AWS_REGION", "us-east-2")
+	defer os.Unsetenv("AWS_REGION")
+	os.Setenv("AWS_SESSION_TOKEN", "TOKEN")
+	defer os.Unsetenv("AWS_SESSION_TOKEN")
+	os.Setenv("HOME", t.TempDir())
+	defer os.Unsetenv("HOME")
+
+	id, secret, region, token, err := AmbientCreds()
+	assert.NoError(t, err)
+	assert.Equal(t, "AKID", id)
+	assert.Equal(t, "SECRET", secret)
+	assert.Equal(t, "us-east-2", region)
+	assert.Equal(t, "TOKEN", token)
+}
+
+func TestAmbientCredsFiles(t *testing.T) {
+	dir := t.TempDir()
+	os.Setenv("HOME", dir)
+	defer os.Unsetenv("HOME")
+
+	os.Unsetenv("AWS_ACCESS_KEY_ID")
+	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+	os.Unsetenv("AWS_REGION")
+	os.Unsetenv("AWS_DEFAULT_REGION")
+
+	awsDir := filepath.Join(dir, ".aws")
+	err := os.MkdirAll(awsDir, 0755)
+	assert.NoError(t, err)
+
+	configPath := filepath.Join(awsDir, "config")
+	credPath := filepath.Join(awsDir, "credentials")
+	err = os.WriteFile(configPath, []byte("[profile default]\nregion=eu-central-1\n"), 0644)
+	assert.NoError(t, err)
+	err = os.WriteFile(credPath, []byte("[default]\naws_access_key_id=IDFILE\naws_secret_access_key=SECF\n"), 0600)
+	assert.NoError(t, err)
+
+	id, secret, region, token, err := AmbientCreds()
+	assert.NoError(t, err)
+	assert.Equal(t, "IDFILE", id)
+	assert.Equal(t, "SECF", secret)
+	assert.Equal(t, "eu-central-1", region)
+	assert.Equal(t, "", token)
 }


### PR DESCRIPTION
## Summary
- extend creds_test with mock STS server for WebIdentityCreds
- test AmbientCreds loading from environment and from AWS config files

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684f0261ba848322a8f09d6039c9491f